### PR TITLE
Update skipping-tests.md

### DIFF
--- a/source/docs/skipping-tests.md
+++ b/source/docs/skipping-tests.md
@@ -10,21 +10,21 @@ section: content
 During development, you may want to temporarily turn off a test. Rather than commenting it out,
 you can use the `skip` method.
 
-> This is the equivalent as `markTestSkipped` in PHPUnit.
+> This is the equivalent of `markTestSkipped` in PHPUnit.
 ```php
 it('has home', function () {
     // ..
 })->skip();
 ```
 
-Of course, you can also leave the skip reason.
+Of course, you can also mention the reason for skipping this test:
 ```php
 it('has home', function () {
     // ..
 })->skip('Home page not available');
 ```
 
-Also, you may want to skip depending on a condition:
+Also, you may want to skip a test depending on a condition:
 ```php
 it('has home', function () {
     // ..
@@ -33,7 +33,7 @@ it('has home', function () {
 
 ## Running a single test
 
-If you’d like to run a single test to debug a problem, just use the following syntax.
+If you’d like to run a single test to debug a problem, just use the following syntax:
 
 ```php
 it('has home', function () {
@@ -44,12 +44,12 @@ it('has home', function () {
 ## Writing a Pending Test
 
 If you’d like to remind yourself to come back and write a test later, just
-omit the closure expression to define a pending test.
+omit the closure expression to define a pending test:
 
 ```php
 it('has home');
 ```
 
-Behind the scenes, Pest will be marked this test as risky as it does not perform any assertions.
+Behind the scenes, Pest will mark this test as risky as it does not perform any assertion.
 
 Next section: [Datasets →](/docs/datasets)


### PR DESCRIPTION
- Very slight grammar rewording.
- Typo corrected.
- All lines preceding examples screenshots now end with a colon, so they all adhere to the same typographic logic.