### PR TITLE
ParseError on examples from documentation

### DIFF
--- a/source/docs/datasets.md
+++ b/source/docs/datasets.md
@@ -21,7 +21,7 @@ datasets in Pest.
 An inline `dataset` may be used for a single test only:
 ```php
 it('has emails', function ($email) {
-    assertNotEmpty($email)
+    assertNotEmpty($email);
 })->with([
     'enunomaduro@gmail.com',
     'other@example.com'
@@ -32,7 +32,7 @@ Of course, you can also give multiple
 arguments providing an array of arguments:
 ```php
 it('has emails', function ($name, $email) {
-    assertNotEmpty($email)
+    assertNotEmpty($email);
 })->with([
     ['Nuno', 'enunomaduro@gmail.com'],
     ['Other', 'other@example.com']
@@ -64,7 +64,7 @@ dataset('emails', [
 In your test, you can use the `dataset` name to reuse your dataset:
 ```php
 it('has emails', function ($email) {
-    assertNotEmpty($email)
+    assertNotEmpty($email);
 })->with('emails');
 ```
 
@@ -83,7 +83,7 @@ dataset('emails', function () {
 });
 
 it('has emails', function ($email) {
-    assertNotEmpty($email)
+    assertNotEmpty($email);
 })->with(function () {
     yield 'enunomaduro@gmail.com';
     yield 'other@example.com';


### PR DESCRIPTION
Hi, 
Samples codes from the [Datasets page](https://pestphp.com/docs/datasets/) throw ParseError Exception.
>  at C:\Labs\pests\tests\Unit\ComponentTest.php:16
     12▕ // });
     13▕
     14▕ it('has emails', function ($email) {
     15▕     assertNotEmpty($email)
  ➜  16▕ })->with([
     17▕     'enunomaduro@gmail.com',
     18▕     'other@example.com'
     19▕ ]);