### PR TITLE
Fix syntax for multiple groups

### DIFF
--- a/source/docs/groups.md
+++ b/source/docs/groups.md
@@ -21,7 +21,7 @@ Of course, you can also assign a test to multiple groups:
 ```php
 it('has home', function () {
     // ..
-})->group(['integration', 'browser']);
+})->group('integration', 'browser');
 ```
 
 Sometimes, you may want to assign an entire file to a group:


### PR DESCRIPTION
This fixes the syntax of the `group()` method when called with multiple groups.

The code for this method specifies `public function group(string ...$groups): TestCall` which requires a list of strings rather than an array.

When running tests using the code identified in the docs, it throws a TypeError.

![image](https://user-images.githubusercontent.com/1899334/82672902-e4dcd200-9c38-11ea-96f8-b13154df6a16.png)
