### PR TITLE
Change ambiguous trait usage wording

### DIFF
--- a/source/docs/guides/laravel.md
+++ b/source/docs/guides/laravel.md
@@ -122,6 +122,6 @@ it('has users')->assertDatabaseHas('users', [
 ```
 
 Keep in mind that you can avoid the `uses(RefreshDatabase::class)`
-line in your test by moving that same line to your `Pest.php` file.
+line in your test by [binding it](/docs/underlying-test-case) in your `Pest.php` file.
 
 Next section: [PHPUnit →](/docs/guides/phpunit)


### PR DESCRIPTION
Moving/adding the line as is does not work with `Pest.php`'s default content after installation. Hint at the "underlying test case section" again to let users figure out how to properly move/add it according to their given setup.

"moving that same line" might be interpreted like this ...

```
use Illuminate\Foundation\Testing\RefreshDatabase;

uses(\Tests\TestCase::class)->in('Feature');
uses(RefreshDatabase::class);
```

... which will not work. Ran into this because i had not read the "underlying test case" section yet - this change makes reading it explicitly relevant for that task.

Might as well just include the full example instead of linking to the same section twice?

```
<?php

use Illuminate\Foundation\Testing\RefreshDatabase;

uses(\Tests\TestCase::class, RefreshDatabase::class)->in('Feature');
```