### PR TITLE
Add new Plugins documentation

### DIFF
--- a/navigation.php
+++ b/navigation.php
@@ -24,6 +24,11 @@ return [
             'Symfony' => 'docs/guides/symfony',
         ],
     ],
+    'Plugins' => [
+        'children' => [
+            'Faker' => 'docs/plugins/faker',
+        ]
+    ],
     'Get involved' => [
         'children' => [
             'Community' => 'docs/community',

--- a/source/docs/guides/symfony.md
+++ b/source/docs/guides/symfony.md
@@ -58,4 +58,4 @@ test('something', function() {
 });
 ```
 
-Next section: [Community →](/docs/community)
+Next section: [Faker →](/docs/plugins/faker)

--- a/source/docs/plugins/faker.md
+++ b/source/docs/plugins/faker.md
@@ -1,0 +1,29 @@
+---
+title: Faker Plugin
+description: The Faker Plugin
+extends: _layouts.documentation
+section: content
+---
+
+# Faker Plugin
+
+The Faker Plugin for Pest provides additional functions for using the [Faker](https://github.com/fzaninotto/Faker) library.
+
+Install the plugin using Composer:
+
+```bash
+composer require pestphp/pest-plugin-faker --dev
+```
+
+This will add the following new global functions for your tests.
+
+### `faker()`
+
+The `faker()` function will create an instance of the Faker generator with the default locale (*en_US*).
+
+### `fakerWithLocale()`
+
+The `fakerWithLocale()` function allows you to specify the locale that is used when
+creating the instance of the Faker generator.
+
+Next section: [Community →](/docs/community)


### PR DESCRIPTION
This adds some (quite simple) documentation on the available plugins for Pest.

Currently I added the following:

- Faker (https://github.com/pestphp/pest-plugin-faker)
- Laravel (https://github.com/pestphp/pest-plugin-laravel)