### PR TITLE
Disable GIF logo with 'prefer-reduced-motion'

### DIFF
--- a/source/_assets/sass/_accessibility.scss
+++ b/source/_assets/sass/_accessibility.scss
@@ -1,0 +1,17 @@
+@media screen and (prefers-reduced-motion: reduce) {
+  .show-on-reduced-motion {
+    display: block;
+  }
+  .hide-on-reduced-motion {
+    display: none;
+  }
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .show-on-reduced-motion {
+    display: none;
+  }
+  .hide-on-reduced-motion {
+    display: block;
+  }
+}

--- a/source/_assets/sass/main.scss
+++ b/source/_assets/sass/main.scss
@@ -7,6 +7,7 @@
 
 @import 'code';
 @import 'base';
+@import 'accessibility';
 @import 'navigation';
 @import 'documentation';
 @import 'search';

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -12,7 +12,8 @@
                   <div>
                      <div class="flex w-full md:w-auto">
                         <a href="/" title="{{ $page->siteName }} home">
-                           <img class="h-10 w-auto md:h-15 lg:h-20" src="/assets/img/small-logo.gif" alt="{{ $page->siteName }} logo">
+                           <img class="h-10 w-auto md:h-15 lg:h-20 hide-on-reduced-motion" src="/assets/img/small-logo.gif" alt="{{ $page->siteName }} logo">
+                           <img class="h-10 w-auto md:h-15 lg:h-20 show-on-reduced-motion" src="/assets/img/logo.png" alt="{{ $page->siteName }} logo">
                         </a>
                      </div>
                   </div>


### PR DESCRIPTION
This hides the GIF logo and replaces it with a PNG when reduced motion is enabled.

I'm not entirely sure what happens on older browsers that don't support this. Any thoughts? 🤔

cc @octoper / @AlexMartinFR

---

See @m1guelpf's comment: https://github.com/pestphp/pest/issues/39#issuecomment-653019070