### PR TITLE
docs: add Global Assertions plugin docs

### DIFF
--- a/navigation.php
+++ b/navigation.php
@@ -31,6 +31,7 @@ return [
             'Laravel' => 'docs/plugins/laravel',
             'Livewire' => 'docs/plugins/livewire',
             'Faker' => 'docs/plugins/faker',
+            'Global Assertions' => 'docs/plugins/global-assertions',
             'Snapshots' => 'docs/plugins/snapshots',
         ]
     ],

--- a/source/docs/plugins/faker.md
+++ b/source/docs/plugins/faker.md
@@ -46,4 +46,4 @@ it('generates a name using faker with locale', function () {
 
 Finally, for the full list of available Faker methods, please refer to the [Faker documentation](https://github.com/fzaninotto/Faker#formatters).
 
-Next section: [Snapshots →](/docs/plugins/snapshots)
+Next section: [Global Assertions →](/docs/plugins/global-assertions)

--- a/source/docs/plugins/global-assertions.md
+++ b/source/docs/plugins/global-assertions.md
@@ -1,0 +1,32 @@
+---
+title: Global Assertions Plugin
+description: A plugin that adds global assertions back to Pest
+extends: _layouts.documentation
+section: content
+---
+
+# Global Assertions Plugin
+
+The Global Assertions Plugin for Pest provides global functions for assertions that were removed in v0.2
+
+**Source code**: [github.com/pestphp/pest-plugin-global-assertions](https://github.com/pestphp/pest-plugin-global-assertions)
+
+Install the plugin using Composer:
+
+```bash
+composer require pestphp/pest-plugin-global-assertions --dev
+```
+
+This allows you to do the following, without calling the `$this` object. For a full list of available methods, please refer to [the compiled list](https://github.com/pestphp/pest-plugin-global-assertions/blob/main/src/compiled.php).
+
+```php
+it('asserts true is true using global function', function () {
+    assertTrue(true);
+});
+```
+
+This plugin is a good temporary helper when upgrading to [the Expectations API](/docs/expectations) in Pest v0.3
+
+---
+
+Next section: [Snapshots →](/docs/plugins/snapshots)


### PR DESCRIPTION
This adds documentation for the [Global Assertions Plugin](https://github.com/pestphp/pest-plugin-global-assertions) / polyfill for v0.3 of Pest.

This shouldn't be merged until v0.3 releases. 👍🏻

---

It's also obviously not a recommended plugin, so not sure if we want some sort of warning, etc.

![Screenshot 2020-08-11 at 18 03 35](https://user-images.githubusercontent.com/1899334/89926552-fcef3c80-dbfc-11ea-97f6-de509ea9c753.png)
