### PR TITLE
Update skipping-tests.md

### DIFF
--- a/source/docs/skipping-tests.md
+++ b/source/docs/skipping-tests.md
@@ -40,7 +40,7 @@ it('has home', function () {
     // ..
 })->only();
 ```
-> Please be aware that `->only()` requires all tests to be written with Pest in order to work correctly.
+> Please be aware that `->only()` requires all tests to be written with Pest test functions in order to work correctly.
 
 
 ## Writing a Pending Test

--- a/source/docs/skipping-tests.md
+++ b/source/docs/skipping-tests.md
@@ -40,6 +40,8 @@ it('has home', function () {
     // ..
 })->only();
 ```
+> Please be aware that `->only()` requires all tests to be written with Pest in order to work correctly.
+
 
 ## Writing a Pending Test
 


### PR DESCRIPTION
Adding a remake only doesn't work correct when not all test are written with Pest functions. See https://github.com/pestphp/pest/issues/183